### PR TITLE
fix: unsubscribe / unsubscribeAll method

### DIFF
--- a/lib/src/messaging.dart
+++ b/lib/src/messaging.dart
@@ -462,14 +462,16 @@ class _Messaging implements Messaging, MessagingQueueDispatcher {
     if (!_subscribers.containsKey(to)) {
       return;
     }
-    _subscribers[to]!.remove(subscriber);
+    _subscribers[to]!.removeWhere(
+        (element) => element.subscriberKey == subscriber.subscriberKey);
     _log.info('${subscriber.subscriberKey} unsubscribes to $to');
   }
 
   @override
   void unsubscribeAll(MessagingSubscriber subscriber) {
     _subscribers.forEach((key, value) {
-      if (value.contains(subscriber)) {
+      if (value.any(
+          (element) => element.subscriberKey == subscriber.subscriberKey)) {
         unsubscribe(subscriber, to: key);
       }
     });


### PR DESCRIPTION
- identification by type subscriber doesn't work
- use subscriberKey to identify when we need to remove MessagingSubscriber